### PR TITLE
Compatibility with Ruby 1.9

### DIFF
--- a/lib/differ/diff.rb
+++ b/lib/differ/diff.rb
@@ -68,7 +68,7 @@ module Differ
     end
 
     def to_s
-      @raw.to_s
+      @raw.join
     end
 
     def format_as(f)


### PR DESCRIPTION
Since Ruby 1.9, Array#to_s is equivalent to Array#inspect.

This commit makes all the specs pass under Ruby 1.9.2.
