### PR TITLE
String methods

### DIFF
--- a/lib/differ/string.rb
+++ b/lib/differ/string.rb
@@ -4,6 +4,18 @@ module Differ
       Differ.diff(self, old, $; || "\n")
     end
     alias :- :diff
+    
+    def diff_by_char(old)
+      Differ.diff(self, old, '')
+    end
+
+    def diff_by_word(old)
+      Differ.diff(self, old, /\b/)
+    end
+
+    def diff_by_line(old)
+      Differ.diff(self, old, "\n")
+    end
   end
 end
 

--- a/spec/differ/string_spec.rb
+++ b/spec/differ/string_spec.rb
@@ -35,4 +35,25 @@ describe Differ::StringDiffer do
       'TO' - 'FROM'
     end
   end
+  
+  describe '#diff_by_char' do
+    it 'should call Differ#diff' do
+      Differ.should_receive(:diff).with('Othellos', 'hello', '').once
+      'Othellos'.diff_by_char('hello')
+    end
+  end
+  
+  describe '#diff_by_word' do
+    it 'should call Differ#diff' do
+      Differ.should_receive(:diff).with('Othellos', 'hello', /\b/).once
+      'Othellos'.diff_by_word('hello')
+    end
+  end
+  
+  describe '#diff_by_line' do
+    it 'should call Differ#diff' do
+      Differ.should_receive(:diff).with('Othellos', 'hello', "\n").once
+      'Othellos'.diff_by_line('hello')
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'differ'
 
-Spec::Runner.configure do |config|
+RSpec.configure do |config|
 
 end
 


### PR DESCRIPTION
Hi!

I went to use `"something".diff_by_char()` and realized that String had only been extended with the `diff()` method so far.

Added:

``` ruby
"something".diff_by_char("something else")
"something".diff_by_word("something else")
"something".diff_by_line("something else")
```

(And a few related specs.)

(Note: Also minor update to `spec_helper.rb` so it stops warning about deprecated rspec2 syntax.)
